### PR TITLE
Increase fact request default Expiry

### DIFF
--- a/fact/client.go
+++ b/fact/client.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	defaultRequestTimeout = time.Minute * 5
+	defaultRequestTimeout = time.Minute * 15
 
 	enc = base64.RawStdEncoding
 )


### PR DESCRIPTION
Aligning this sdk with ruby one by increasing the default fact request timeout from 5 minutes to 15.t