### PR TITLE
Make storage_dir mandatory on client initialization

### DIFF
--- a/config.go
+++ b/config.go
@@ -83,6 +83,10 @@ func (c Config) validate() error {
 		return errors.New("config must specify a key to encrypt storage")
 	}
 
+	if c.StorageDir == "" {
+		return errors.New("config must specify a storage directory")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Due to the uncommon nature of the SDK needing to store state means having a default for this value can easily lead to nothing working and confusion.
Forcing the user to declare it means they are more likely to question what it is/does and visit the documentation to find out.

