### PR TITLE
Migrate storage folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ import "github.com/joinself/self-go-sdk"
 
 func main() {
     cfg := selfsdk.Config{
-		SelfAppID:     os.Getenv("SELF_APP_ID"),
-		SelfAppSecret: os.Getenv("SELF_APP_SECRET"),
-		StorageDir:    "/opt/self/crypto",
-		StorageKey:    "my-secret-crypto-storage-key",
+		SelfAppID:           os.Getenv("SELF_APP_ID"),
+		SelfAppDeviceSecret: os.Getenv("SELF_APP_DEVICE_SECRET"),
+		StorageDir:          "/opt/self/crypto",
+		StorageKey:          "my-secret-crypto-storage-key",
 	}
 
     client, err := selfsdk.New(cfg)

--- a/_examples/authentication/README.md
+++ b/_examples/authentication/README.md
@@ -8,10 +8,10 @@ As part of this process, you will provide your users with a user interface so th
 
 In order to run this example, you must have a valid app id and private key. Self credentials are issued by the [Self Developer portal](https://developer.joinself.com/) when you create a new app.
 
-Once you have your valid `SELF_APP_ID` and `SELF_APP_SECRET` you can run this example with:
+Once you have your valid `SELF_APP_ID` and `SELF_APP_DEVICE_SECRET` you can run this example with:
 
 ```bash
-$ SELF_APP_ID=XXXXX SELF_APP_SECRET=XXXXXXXX go run authentication.go <your_users_self_id>
+$ SELF_APP_ID=XXXXX SELF_APP_DEVICE_SECRET=XXXXXXXX go run authentication.go <your_users_self_id>
 ```
 
 Note you must provide a valid user self_id for `your_users_self_id`. This example will send an authentication request to this self_id, so keep an eye on the user's device to look for the authentication request.

--- a/_examples/authentication/authentication.go
+++ b/_examples/authentication/authentication.go
@@ -12,10 +12,10 @@ import (
 // expects 1 argument - the Self ID you want to authenticate
 func main() {
 	cfg := selfsdk.Config{
-		SelfAppID:     os.Getenv("SELF_APP_ID"),
-		SelfAppSecret: os.Getenv("SELF_APP_SECRET"),
-		StorageKey:    "my-secret-crypto-storage-key",
-		StorageDir:    "../.storage/" + os.Getenv("SELF_APP_ID"),
+		SelfAppID:           os.Getenv("SELF_APP_ID"),
+		SelfAppDeviceSecret: os.Getenv("SELF_APP_DEVICE_SECRET"),
+		StorageKey:          "my-secret-crypto-storage-key",
+		StorageDir:          "../.storage/" + os.Getenv("SELF_APP_ID"),
 	}
 
 	if os.Getenv("SELF_ENV") != "" {

--- a/_examples/authentication_dl/README.md
+++ b/_examples/authentication_dl/README.md
@@ -8,10 +8,10 @@ As part of this process, you have to share the generated deep link code with you
 
 In order to run this example, you must have a valid app id and private key. Self credentials are issued by the [Self Developer portal](https://developer.joinself.com/) when you create a new app.
 
-Once you have your valid `SELF_APP_ID` and `SELF_APP_SECRET` you can run this example with:
+Once you have your valid `SELF_APP_ID` and `SELF_APP_DEVICE_SECRET` you can run this example with:
 
 ```bash
-$ SELF_APP_ID=XXXXX SELF_APP_SECRET=XXXXXXXX go run authentication.go
+$ SELF_APP_ID=XXXXX SELF_APP_DEVICE_SECRET=XXXXXXXX go run authentication.go
 ```
 
 Running this command will open the qr code in a browser, which you will need to scan with the self app on your device.

--- a/_examples/authentication_dl/authentication.go
+++ b/_examples/authentication_dl/authentication.go
@@ -15,10 +15,10 @@ import (
 // expects 1 argument - the Self ID you want to authenticate
 func main() {
 	cfg := selfsdk.Config{
-		SelfAppID:     os.Getenv("SELF_APP_ID"),
-		SelfAppSecret: os.Getenv("SELF_APP_SECRET"),
-		StorageKey:    "my-secret-crypto-storage-key",
-		StorageDir:    "../.storage/" + os.Getenv("SELF_APP_ID"),
+		SelfAppID:           os.Getenv("SELF_APP_ID"),
+		SelfAppDeviceSecret: os.Getenv("SELF_APP_DEVICE_SECRET"),
+		StorageKey:          "my-secret-crypto-storage-key",
+		StorageDir:          "../.storage/" + os.Getenv("SELF_APP_ID"),
 	}
 
 	if os.Getenv("SELF_ENV") != "" {

--- a/_examples/authentication_qr/README.md
+++ b/_examples/authentication_qr/README.md
@@ -8,10 +8,10 @@ As part of this process, you have to share the generated QR code with your users
 
 In order to run this example, you must have a valid app id and private key. Self credentials are issued by the [Self Developer portal](https://developer.joinself.com/) when you create a new app.
 
-Once you have your valid `SELF_APP_ID` and `SELF_APP_SECRET` you can run this example with:
+Once you have your valid `SELF_APP_ID` and `SELF_APP_DEVICE_SECRET` you can run this example with:
 
 ```bash
-$ SELF_APP_ID=XXXXX SELF_APP_SECRET=XXXXXXXX go run authentication.go
+$ SELF_APP_ID=XXXXX SELF_APP_DEVICE_SECRET=XXXXXXXX go run authentication.go
 ```
 
 Running this command will open the qr code in a browser, which you will need to scan with the self app on your device.

--- a/_examples/authentication_qr/authentication.go
+++ b/_examples/authentication_qr/authentication.go
@@ -18,10 +18,10 @@ import (
 
 func main() {
 	cfg := selfsdk.Config{
-		SelfAppID:     os.Getenv("SELF_APP_ID"),
-		SelfAppSecret: os.Getenv("SELF_APP_SECRET"),
-		StorageKey:    "my-secret-crypto-storage-key",
-		StorageDir:    "../.storage/" + os.Getenv("SELF_APP_ID"),
+		SelfAppID:           os.Getenv("SELF_APP_ID"),
+		SelfAppDeviceSecret: os.Getenv("SELF_APP_DEVICE_SECRET"),
+		StorageKey:          "my-secret-crypto-storage-key",
+		StorageDir:          "../.storage/" + os.Getenv("SELF_APP_ID"),
 	}
 
 	if os.Getenv("SELF_ENV") != "" {

--- a/_examples/authentication_qr/service/authentication_service.go
+++ b/_examples/authentication_qr/service/authentication_service.go
@@ -20,10 +20,10 @@ import (
 
 func main() {
 	cfg := selfsdk.Config{
-		SelfAppID:     os.Getenv("SELF_APP_ID"),
-		SelfAppSecret: os.Getenv("SELF_APP_SECRET"),
-		StorageKey:    "my-secret-crypto-storage-key",
-		StorageDir:    "../.storage/" + os.Getenv("SELF_APP_ID"),
+		SelfAppID:           os.Getenv("SELF_APP_ID"),
+		SelfAppDeviceSecret: os.Getenv("SELF_APP_DEVICE_SECRET"),
+		StorageKey:          "my-secret-crypto-storage-key",
+		StorageDir:          "../.storage/" + os.Getenv("SELF_APP_ID"),
 	}
 
 	if os.Getenv("SELF_ENV") != "" {

--- a/_examples/connections/connections.go
+++ b/_examples/connections/connections.go
@@ -14,10 +14,10 @@ import (
 // expects 1 argument - the Self ID you want to permit
 func main() {
 	cfg := selfsdk.Config{
-		SelfAppID:     os.Getenv("SELF_APP_ID"),
-		SelfAppSecret: os.Getenv("SELF_APP_SECRET"),
-		StorageKey:    "my-secret-crypto-storage-key",
-		StorageDir:    "../.storage/" + os.Getenv("SELF_APP_ID"),
+		SelfAppID:           os.Getenv("SELF_APP_ID"),
+		SelfAppDeviceSecret: os.Getenv("SELF_APP_DEVICE_SECRET"),
+		StorageKey:          "my-secret-crypto-storage-key",
+		StorageDir:          "../.storage/" + os.Getenv("SELF_APP_ID"),
 	}
 
 	if os.Getenv("SELF_ENV") != "" {

--- a/_examples/fact_request/README.md
+++ b/_examples/fact_request/README.md
@@ -6,10 +6,10 @@ Your app can request your users to share attested facts about themselves. To do 
 
 In order to run this example, you must have a valid app id and private key. Self credentials are issued by the [Self Developer portal](https://developer.joinself.com/) when you create a new app.
 
-Once you have your valid `SELF_APP_ID` and `SELF_APP_SECRET` you can run this example with:
+Once you have your valid `SELF_APP_ID` and `SELF_APP_DEVICE_SECRET` you can run this example with:
 
 ```bash
-$ SELF_APP_ID=XXXXX SELF_APP_SECRET=XXXXXXXX go run fact.go <your_users_self_id>
+$ SELF_APP_ID=XXXXX SELF_APP_DEVICE_SECRET=XXXXXXXX go run fact.go <your_users_self_id>
 ```
 
 Note you must provide a valid user self_id for `your_users_self_id`. This example will send a fact request to this self_id's devices, so keep an eye on the user's device to look for the fact request.

--- a/_examples/fact_request/fact.go
+++ b/_examples/fact_request/fact.go
@@ -14,10 +14,10 @@ import (
 // expects 1 argument - the Self ID you want to authenticate
 func main() {
 	cfg := selfsdk.Config{
-		SelfAppID:     os.Getenv("SELF_APP_ID"),
-		SelfAppSecret: os.Getenv("SELF_APP_SECRET"),
-		StorageKey:    "my-secret-crypto-storage-key",
-		StorageDir:    "../.storage/" + os.Getenv("SELF_APP_ID"),
+		SelfAppID:           os.Getenv("SELF_APP_ID"),
+		SelfAppDeviceSecret: os.Getenv("SELF_APP_DEVICE_SECRET"),
+		StorageKey:          "my-secret-crypto-storage-key",
+		StorageDir:          "../.storage/" + os.Getenv("SELF_APP_ID"),
 	}
 
 	if os.Getenv("SELF_ENV") != "" {

--- a/_examples/fact_request_dl/README.md
+++ b/_examples/fact_request_dl/README.md
@@ -9,10 +9,10 @@ As part of this process, you have to share the generated Deep link with your use
 
 In order to run this example, you must have a valid app id and private key. Self credentials are issued by the [Self Developer portal](https://developer.joinself.com/) when you create a new app.
 
-Once you have your valid `SELF_APP_ID` and `SELF_APP_SECRET` you can run this example with:
+Once you have your valid `SELF_APP_ID` and `SELF_APP_DEVICE_SECRET` you can run this example with:
 
 ```bash
-$ SELF_APP_ID=XXXXX SELF_APP_SECRET=XXXXXXXX go run fact.go
+$ SELF_APP_ID=XXXXX SELF_APP_DEVICE_SECRET=XXXXXXXX go run fact.go
 ```
 
 ## Process diagram

--- a/_examples/fact_request_dl/fact.go
+++ b/_examples/fact_request_dl/fact.go
@@ -17,10 +17,10 @@ func main() {
 	cid := uuid.New().String()
 
 	cfg := selfsdk.Config{
-		SelfAppID:     os.Getenv("SELF_APP_ID"),
-		SelfAppSecret: os.Getenv("SELF_APP_SECRET"),
-		StorageKey:    "my-secret-crypto-storage-key",
-		StorageDir:    "../.storage/" + os.Getenv("SELF_APP_ID"),
+		SelfAppID:           os.Getenv("SELF_APP_ID"),
+		SelfAppDeviceSecret: os.Getenv("SELF_APP_DEVICE_SECRET"),
+		StorageKey:          "my-secret-crypto-storage-key",
+		StorageDir:          "../.storage/" + os.Getenv("SELF_APP_ID"),
 	}
 
 	if os.Getenv("SELF_ENV") != "" {

--- a/_examples/fact_request_intermediary/README.md
+++ b/_examples/fact_request_intermediary/README.md
@@ -8,10 +8,10 @@ This reduces the liabilities of having to securely store user information and co
 
 In order to run this example, you must have a valid app id and private key. Self credentials are issued by the [Self Developer portal](https://developer.joinself.com/) when you create a new app.
 
-Once you have your valid `SELF_APP_ID` and `SELF_APP_SECRET` you can run this example with:
+Once you have your valid `SELF_APP_ID` and `SELF_APP_DEVICE_SECRET` you can run this example with:
 
 ```bash
-$ SELF_INTERMEDIARY=XXXX SELF_APP_ID=XXXXX SELF_APP_SECRET=XXXXXXXX go run fact.go <your_users_self_id>
+$ SELF_INTERMEDIARY=XXXX SELF_APP_ID=XXXXX SELF_APP_DEVICE_SECRET=XXXXXXXX go run fact.go <your_users_self_id>
 ```
 
 Note you must provide a valid user self_id for `your_users_self_id`. This example will send a fact request to this self_id's devices, so keep an eye on the user's device to look for the fact request.

--- a/_examples/fact_request_intermediary/fact.go
+++ b/_examples/fact_request_intermediary/fact.go
@@ -14,10 +14,10 @@ import (
 // expects 2 arguments - the Self ID you want to authenticate and the self ID of the intermediary to use
 func main() {
 	cfg := selfsdk.Config{
-		SelfAppID:     os.Getenv("SELF_APP_ID"),
-		SelfAppSecret: os.Getenv("SELF_APP_SECRET"),
-		StorageKey:    "my-secret-crypto-storage-key",
-		StorageDir:    "../.storage/" + os.Getenv("SELF_APP_ID"),
+		SelfAppID:           os.Getenv("SELF_APP_ID"),
+		SelfAppDeviceSecret: os.Getenv("SELF_APP_DEVICE_SECRET"),
+		StorageKey:          "my-secret-crypto-storage-key",
+		StorageDir:          "../.storage/" + os.Getenv("SELF_APP_ID"),
 	}
 
 	if os.Getenv("SELF_ENV") != "" {

--- a/_examples/fact_request_qr/README.md
+++ b/_examples/fact_request_qr/README.md
@@ -9,10 +9,10 @@ As part of this process, you have to share the generated QR code with your users
 
 In order to run this example, you must have a valid app id and private key. Self credentials are issued by the [Self Developer portal](https://developer.joinself.com/) when you create a new app.
 
-Once you have your valid `SELF_APP_ID` and `SELF_APP_SECRET` you can run this example with:
+Once you have your valid `SELF_APP_ID` and `SELF_APP_DEVICE_SECRET` you can run this example with:
 
 ```bash
-$ SELF_APP_ID=XXXXX SELF_APP_SECRET=XXXXXXXX go run fact.go
+$ SELF_APP_ID=XXXXX SELF_APP_DEVICE_SECRET=XXXXXXXX go run fact.go
 ```
 
 ## Process diagram

--- a/_examples/fact_request_qr/fact.go
+++ b/_examples/fact_request_qr/fact.go
@@ -18,10 +18,10 @@ import (
 
 func main() {
 	cfg := selfsdk.Config{
-		SelfAppID:     os.Getenv("SELF_APP_ID"),
-		SelfAppSecret: os.Getenv("SELF_APP_SECRET"),
-		StorageKey:    "my-secret-crypto-storage-key",
-		StorageDir:    "../.storage/" + os.Getenv("SELF_APP_ID"),
+		SelfAppID:           os.Getenv("SELF_APP_ID"),
+		SelfAppDeviceSecret: os.Getenv("SELF_APP_DEVICE_SECRET"),
+		StorageKey:          "my-secret-crypto-storage-key",
+		StorageDir:          "../.storage/" + os.Getenv("SELF_APP_ID"),
 	}
 
 	if os.Getenv("SELF_ENV") != "" {

--- a/config.go
+++ b/config.go
@@ -324,8 +324,8 @@ func (c *Config) migrateStorage() error {
 	var sessions []string
 	var offsetFile string
 
-	c.offsetStorageDir = filepath.Join(c.StorageDir, "devices", c.DeviceID)
-	c.cryptoStorageDir = filepath.Join(c.StorageDir, "devices", c.DeviceID, "keys", c.kid)
+	c.offsetStorageDir = filepath.Join(c.StorageDir, "apps", c.SelfAppID, "devices", c.DeviceID)
+	c.cryptoStorageDir = filepath.Join(c.StorageDir, "apps", c.SelfAppID, "devices", c.DeviceID, "keys", c.kid)
 
 	err := os.MkdirAll(c.cryptoStorageDir, 0744)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -344,7 +344,7 @@ func (c *Config) migrateStorage() error {
 			return nil
 		}
 
-		if np[1] == "offset" {
+		if np[1] == "offset" && filepath.Dir(path) != c.offsetStorageDir {
 			if offsetFile != "" {
 				return errors.New("multiple offset files found. please remove the old offset file")
 			}

--- a/config.go
+++ b/config.go
@@ -215,7 +215,7 @@ func (c Config) loadWebsocketConnector() error {
 
 	cfg := transport.WebsocketConfig{
 		MessagingURL: c.MessagingURL,
-		StorageDir:   c.StorageDir,
+		StorageDir:   c.offsetStorageDir,
 		SelfID:       c.SelfAppID,
 		KeyID:        c.kid,
 		DeviceID:     c.DeviceID,
@@ -240,7 +240,7 @@ func (c Config) loadStorageConnector() error {
 	}
 
 	cfg := crypto.StorageConfig{
-		StorageDir: c.StorageDir,
+		StorageDir: c.cryptoStorageDir,
 	}
 
 	client, err := crypto.NewFileStorage(cfg)

--- a/config_test.go
+++ b/config_test.go
@@ -5,10 +5,13 @@ package selfsdk
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"golang.org/x/crypto/ed25519"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,7 +66,7 @@ func TestConfigValidate(t *testing.T) {
 	err = cfg.validate()
 	assert.NotNil(t, err)
 
-	cfg.SelfAppSecret = "1:private-key"
+	cfg.SelfAppDeviceSecret = "1:private-key"
 	err = cfg.validate()
 	assert.NotNil(t, err)
 
@@ -84,11 +87,11 @@ func TestConfigLoad(t *testing.T) {
 	require.Nil(t, err)
 
 	cfg := Config{
-		SelfAppID:     "self-id",
-		DeviceID:      "device-id",
-		SelfAppSecret: "1:" + base64.RawStdEncoding.EncodeToString(sk.Seed()),
-		StorageKey:    "super-secret-encryption-key",
-		StorageDir:    "/tmp/test",
+		SelfAppID:           "self-id",
+		DeviceID:            "device-id",
+		SelfAppDeviceSecret: "1:" + base64.RawStdEncoding.EncodeToString(sk.Seed()),
+		StorageKey:          "super-secret-encryption-key",
+		StorageDir:          "/tmp/test",
 		Connectors: &Connectors{
 			Rest:      &trt,
 			Websocket: &twt,
@@ -116,10 +119,11 @@ func TestConfigLoadWithEnvironment(t *testing.T) {
 	require.Nil(t, err)
 
 	cfg := Config{
-		SelfAppID:     "self-id",
-		SelfAppSecret: "1:" + base64.RawStdEncoding.EncodeToString(sk.Seed()),
-		StorageKey:    "super-secret-encryption-key",
-		Environment:   "sandbox",
+		SelfAppID:           "self-id",
+		SelfAppDeviceSecret: "1:" + base64.RawStdEncoding.EncodeToString(sk.Seed()),
+		StorageKey:          "super-secret-encryption-key",
+		StorageDir:          "/tmp/test",
+		Environment:         "sandbox",
 		Connectors: &Connectors{
 			Rest:      &trt,
 			Websocket: &twt,
@@ -132,4 +136,47 @@ func TestConfigLoadWithEnvironment(t *testing.T) {
 
 	assert.Equal(t, cfg.APIURL, "https://api.sandbox.joinself.com")
 	assert.Equal(t, cfg.MessagingURL, "wss://messaging.sandbox.joinself.com/v1/messaging")
+}
+
+func TestConfigStorageMigration(t *testing.T) {
+	testPath := filepath.Join("/tmp", uuid.New().String())
+
+	err := os.Mkdir(testPath, 0755)
+	require.Nil(t, err)
+
+	defer os.RemoveAll(testPath)
+
+	// create some test files that need to be moved to the new layout
+	for _, f := range []string{"test:1.offset", "account.pickle", "app:1-session.pickle", "app:2-session.pickle", "app:3-session.pickle"} {
+		_, err = os.Create(filepath.Join(testPath, f))
+		require.Nil(t, err)
+	}
+
+	cfg := Config{
+		SelfAppID:           "self-id",
+		SelfAppDeviceSecret: "4:MY-DEVICE-KEY",
+		StorageKey:          "super-secret-encryption-key",
+		StorageDir:          testPath,
+		DeviceID:            "1",
+		kid:                 "4",
+	}
+
+	err = cfg.migrateStorage()
+	require.Nil(t, err)
+
+	// check files have been moved
+	_, err = os.Stat(filepath.Join(testPath, "devices/1/test:1.offset"))
+	assert.Nil(t, err)
+
+	_, err = os.Stat(filepath.Join(testPath, "devices/1/keys/4/account.pickle"))
+	assert.Nil(t, err)
+
+	_, err = os.Stat(filepath.Join(testPath, "devices/1/keys/4/app:1-session.pickle"))
+	assert.Nil(t, err)
+
+	_, err = os.Stat(filepath.Join(testPath, "devices/1/keys/4/app:2-session.pickle"))
+	assert.Nil(t, err)
+
+	_, err = os.Stat(filepath.Join(testPath, "devices/1/keys/4/app:3-session.pickle"))
+	assert.Nil(t, err)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -167,19 +167,19 @@ func TestConfigStorageMigration(t *testing.T) {
 	require.Nil(t, err)
 
 	// check files have been moved
-	_, err = os.Stat(filepath.Join(testPath, "devices/1/test:1.offset"))
+	_, err = os.Stat(filepath.Join(testPath, "apps/self-id/devices/1/test:1.offset"))
 	assert.Nil(t, err)
 
-	_, err = os.Stat(filepath.Join(testPath, "devices/1/keys/4/account.pickle"))
+	_, err = os.Stat(filepath.Join(testPath, "apps/self-id/devices/1/keys/4/account.pickle"))
 	assert.Nil(t, err)
 
-	_, err = os.Stat(filepath.Join(testPath, "devices/1/keys/4/app:1-session.pickle"))
+	_, err = os.Stat(filepath.Join(testPath, "apps/self-id/devices/1/keys/4/app:1-session.pickle"))
 	assert.Nil(t, err)
 
-	_, err = os.Stat(filepath.Join(testPath, "devices/1/keys/4/app:2-session.pickle"))
+	_, err = os.Stat(filepath.Join(testPath, "apps/self-id/devices/1/keys/4/app:2-session.pickle"))
 	assert.Nil(t, err)
 
-	_, err = os.Stat(filepath.Join(testPath, "devices/1/keys/4/app:3-session.pickle"))
+	_, err = os.Stat(filepath.Join(testPath, "apps/self-id/devices/1/keys/4/app:3-session.pickle"))
 	assert.Nil(t, err)
 
 	// test second migration

--- a/config_test.go
+++ b/config_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/ed25519"
 
@@ -23,7 +24,8 @@ func (t *testWebsocketTransport) Send(recipients []string, data []byte) error {
 }
 
 func (t *testWebsocketTransport) Receive() (string, []byte, error) {
-	return "", nil, nil
+	time.Sleep(time.Minute)
+	return "test:1", []byte("{}"), nil
 }
 
 func (t *testWebsocketTransport) Command(command string, payload []byte) ([]byte, error) {
@@ -179,4 +181,8 @@ func TestConfigStorageMigration(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(testPath, "devices/1/keys/4/app:3-session.pickle"))
 	assert.Nil(t, err)
+
+	// test second migration
+	err = cfg.migrateStorage()
+	require.Nil(t, err)
 }

--- a/pkg/messaging/messaging.go
+++ b/pkg/messaging/messaging.go
@@ -33,7 +33,7 @@ type Transport interface {
 	Close() error
 }
 
-// Cryto the crytographic provider used to encrypt and decrypt messages
+// Crypto the crytographic provider used to encrypt and decrypt messages
 type Crypto interface {
 	Encrypt(recipients []string, plaintext []byte) ([]byte, error)
 	Decrypt(sender string, ciphertext []byte) ([]byte, error)


### PR DESCRIPTION
- [x] Migrates the offset file from a little endian encoded int64 written as bytes, to a padded string
- [x] Migrates the offset file to sit under `$STORAGE/apps/$APPID/devices/$DEVICEID/$APPID:$DEVICEID.offset`
- [x] Migrates any crypto session or account files to `$STORAGE/apps/$APPID/devices/$DEVICEID/keys/$KEYID/...`

The structure of the storage folder should now be:
```
└── apps
    └── self-id
        └── devices
            └── 1
                ├── keys
                │   └── 4
                │       ├── account.pickle
                │       ├── app:1-session.pickle
                │       ├── app:2-session.pickle
                │       └── app:3-session.pickle
                └── test:1.offset
```