### PR TITLE
Fix crypto storage, prekey publishing and error handling on messaging loop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/beevik/ntp v0.2.0
-	github.com/davecgh/go-spew v1.1.0
 	github.com/golang/protobuf v1.4.1
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -270,7 +270,6 @@ func (c *Client) publishPreKeys(a *selfcrypto.Account) error {
 	for k, v := range otks.Curve25519 {
 		_, ok := potks.Curve25519[k]
 		if ok {
-			log.Println("crypto: skip publishing prekey", k)
 			continue
 		}
 		pkb = append(pkb, prekey{ID: k, Key: v})

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -21,6 +21,7 @@ import (
 var defaultPreKeyBundleSize = 100
 
 var (
+	// ErrInvalidGroupMessageRecipient a received message is not intended for this identity
 	ErrInvalidGroupMessageRecipient = errors.New("group message does not contain a recipient header for this identity")
 )
 

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -237,7 +237,7 @@ func TestCryptoClientDecrypt(t *testing.T) {
 }
 
 func TestCryptoClientExhaustPreKeys(t *testing.T) {
-	senders, pki, astorage := setup(t, 101)
+	senders, pki, astorage := setup(t, 100)
 
 	// setup alice
 	apk, ask, err := ed25519.GenerateKey(rand.Reader)

--- a/pkg/crypto/storage.go
+++ b/pkg/crypto/storage.go
@@ -55,7 +55,7 @@ func (s *FileStorage) SetAccount(account []byte) error {
 		return err
 	}
 
-	wb, err := f.Write(account)
+	wb, err := f.WriteAt(account, 0)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (s *FileStorage) SetSession(id string, session []byte) error {
 		return err
 	}
 
-	wb, err := f.Write(session)
+	wb, err := f.WriteAt(session, 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/crypto/storage.go
+++ b/pkg/crypto/storage.go
@@ -50,12 +50,12 @@ func (s *FileStorage) GetAccount() ([]byte, error) {
 func (s *FileStorage) SetAccount(account []byte) error {
 	p := filepath.Join(s.config.StorageDir, "account.pickle")
 
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0600)
+	f, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
 
-	wb, err := f.WriteAt(account, 0)
+	wb, err := f.Write(account)
 	if err != nil {
 		return err
 	}
@@ -91,12 +91,12 @@ func (s *FileStorage) GetSession(id string) ([]byte, error) {
 func (s *FileStorage) SetSession(id string, session []byte) error {
 	p := filepath.Join(s.config.StorageDir, id+"-session.pickle")
 
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0600)
+	f, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
 
-	wb, err := f.WriteAt(session, 0)
+	wb, err := f.Write(session)
 	if err != nil {
 		return err
 	}

--- a/pkg/crypto/storage.go
+++ b/pkg/crypto/storage.go
@@ -49,7 +49,27 @@ func (s *FileStorage) GetAccount() ([]byte, error) {
 // SetAccount persists an accounts encoded and encrypted pickle
 func (s *FileStorage) SetAccount(account []byte) error {
 	p := filepath.Join(s.config.StorageDir, "account.pickle")
-	return ioutil.WriteFile(p, account, 0600)
+
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return err
+	}
+
+	wb, err := f.Write(account)
+	if err != nil {
+		return err
+	}
+
+	if wb != len(account) {
+		return errors.New("incomplete write of encrypted account")
+	}
+
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	return f.Close()
 }
 
 // GetSession gets an sessions encoded and encrypted pickle
@@ -70,5 +90,25 @@ func (s *FileStorage) GetSession(id string) ([]byte, error) {
 // SetSession persists an sessions encoded and encrypted pickle
 func (s *FileStorage) SetSession(id string, session []byte) error {
 	p := filepath.Join(s.config.StorageDir, id+"-session.pickle")
-	return ioutil.WriteFile(p, session, 0600)
+
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return err
+	}
+
+	wb, err := f.Write(session)
+	if err != nil {
+		return err
+	}
+
+	if wb != len(session) {
+		return errors.New("incomplete write of encrypted session")
+	}
+
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	return f.Close()
 }

--- a/pkg/crypto/storage.go
+++ b/pkg/crypto/storage.go
@@ -10,6 +10,7 @@ import (
 )
 
 var (
+	// ErrNotExist file does not exist
 	ErrNotExist = os.ErrNotExist
 )
 var perr *os.PathError
@@ -24,7 +25,7 @@ type FileStorage struct {
 	config StorageConfig
 }
 
-// NewStorage creates a new storage client that persists to files
+// NewFileStorage creates a new storage client that persists to files
 func NewFileStorage(config StorageConfig) (*FileStorage, error) {
 	return &FileStorage{config}, os.MkdirAll(config.StorageDir, 0700)
 }
@@ -66,7 +67,7 @@ func (s *FileStorage) GetSession(id string) ([]byte, error) {
 	return data, nil
 }
 
-// SetAccount persists an sessions encoded and encrypted pickle
+// SetSession persists an sessions encoded and encrypted pickle
 func (s *FileStorage) SetSession(id string, session []byte) error {
 	p := filepath.Join(s.config.StorageDir, id+"-session.pickle")
 	return ioutil.WriteFile(p, session, 0600)

--- a/pkg/crypto/support_test.go
+++ b/pkg/crypto/support_test.go
@@ -186,7 +186,7 @@ func (p *testPKI) GetDeviceKey(selfID, deviceID string) ([]byte, error) {
 
 	kid := p.dkoff[selfID+":"+deviceID]
 
-	if kid > len(keys) {
+	if kid > len(keys)-1 {
 		return nil, errors.New("prekeys exhausted")
 	}
 

--- a/pkg/messaging/messaging.go
+++ b/pkg/messaging/messaging.go
@@ -198,7 +198,7 @@ func (c *Client) reader() {
 		sender, ciphertext, err := c.transport.Receive()
 		if err != nil {
 			log.Println("messaging:", err)
-			return
+			continue
 		}
 
 		plaintext, err := c.crypto.Decrypt(sender, ciphertext)
@@ -209,13 +209,14 @@ func (c *Client) reader() {
 
 		encPayload := gjson.GetBytes(plaintext, "payload").String()
 		if encPayload == "" {
-			return
+			log.Println("messaging: invalid jws message")
+			continue
 		}
 
 		payload, err := decoder.DecodeString(encPayload)
 		if err != nil {
 			log.Println("messaging:", err)
-			return
+			continue
 		}
 
 		cid := gjson.GetBytes(payload, "cid").String()


### PR DESCRIPTION
- [x] dont exit messaging loop on an error
- [x] safely fsync account and session data to disk
- [x] skip publishing prekeys that have already been published