### PR TITLE
don't exit on events that aren't in the responses map

### DIFF
--- a/config.go
+++ b/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	Environment          string
 	OnConnect            func()
 	OnDisconnect         func()
+	OnPing               func()
 	ReconnectionAttempts int
 	TCPDeadline          time.Duration
 	RequestTimeout       time.Duration
@@ -226,6 +227,7 @@ func (c Config) loadWebsocketConnector() error {
 		InboxSize:    defaultInboxSize,
 		OnConnect:    c.OnConnect,
 		OnDisconnect: c.OnDisconnect,
+		OnPing:       c.OnPing,
 	}
 
 	ws, err := transport.NewWebsocket(cfg)

--- a/pkg/transport/websocket.go
+++ b/pkg/transport/websocket.go
@@ -51,6 +51,7 @@ type WebsocketConfig struct {
 	InboxSize    int
 	OnConnect    func()
 	OnDisconnect func()
+	OnPing       func()
 	messagingID  string
 }
 
@@ -434,7 +435,7 @@ func (c *Websocket) reader() {
 
 			pch, ok := c.responses.Load(n.Id)
 			if !ok {
-				return
+				continue
 			}
 
 			c.responses.Delete(n.Id)
@@ -457,7 +458,7 @@ func (c *Websocket) reader() {
 
 			pch, ok := c.responses.Load(a.Id)
 			if !ok {
-				return
+				continue
 			}
 
 			c.responses.Delete(a.Id)
@@ -518,6 +519,10 @@ func (c *Websocket) ping() {
 	for {
 		if c.isClosed() {
 			return
+		}
+
+		if c.config.OnPing != nil {
+			c.config.OnPing()
 		}
 
 		c.queue.Push(priorityPing, sigping(true))


### PR DESCRIPTION
- [x] add websocket pong callback
- [x] dont exit websocket reader loop if an event id is not present in the response map