### PR TITLE
handle unexpected EOF when connection dies

### DIFF
--- a/pkg/transport/websocket.go
+++ b/pkg/transport/websocket.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -542,7 +543,9 @@ func (c *Websocket) reconnect(err error) {
 		}
 	case *websocket.CloseError:
 		if e.Code != websocket.CloseAbnormalClosure {
-			return
+			if e.Text != io.ErrUnexpectedEOF.Error() {
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
Handles disconnects where the connection dies while reading, which caused the client to not attempt a reconnect