### PR TITLE
use custom domain for dynamic links

### DIFF
--- a/authentication/authenticate.go
+++ b/authentication/authenticate.go
@@ -182,13 +182,13 @@ func (s *Service) GenerateDeepLink(req *DeepLinkAuthenticationRequest) (string, 
 		return "", err
 	}
 
-	url := "https://joinself.page.link/?link=" + req.Callback + "%3Fqr=" + base64.RawStdEncoding.EncodeToString(payload)
+	url := "https://links.joinself.com/?link=" + req.Callback + "%3Fqr=" + base64.RawStdEncoding.EncodeToString(payload)
 	if s.environment == "" {
 		return url + "&apn=com.joinself.app", nil
 	} else if s.environment == "development" {
 		return url + "&apn=com.joinself.app.dev", nil
 	}
-	return url + "&apn=com.joinself.app." + s.environment, nil
+	return "https://" + s.environment + ".links.joinself.com/?link=" + req.Callback + "%3Fqr=" + base64.RawStdEncoding.EncodeToString(payload) + "&apn=com.joinself.app." + s.environment, nil
 }
 
 // WaitForResponse waits for a response from a qr code authentication request

--- a/fact/request.go
+++ b/fact/request.go
@@ -345,13 +345,13 @@ func (s Service) GenerateDeepLink(req *DeepLinkFactRequest) (string, error) {
 		return "", err
 	}
 
-	url := "https://joinself.page.link/?link=" + req.Callback + "%3Fqr=" + base64.RawStdEncoding.EncodeToString(payload)
+	url := "https://links.joinself.com/?link=" + req.Callback + "%3Fqr=" + base64.RawStdEncoding.EncodeToString(payload)
 	if s.environment == "" {
 		return url + "&apn=com.joinself.app", nil
 	} else if s.environment == "development" {
 		return url + "&apn=com.joinself.app.dev", nil
 	}
-	return url + "&apn=com.joinself.app." + s.environment, nil
+	return "https://" + s.environment + ".links.joinself.com/?link=" + req.Callback + "%3Fqr=" + base64.RawStdEncoding.EncodeToString(payload) + "&apn=com.joinself.app." + s.environment, nil
 }
 
 // WaitForResponse waits for completion of a fact request that was initiated by qr code


### PR DESCRIPTION
Firebase Dynamic Links do not support using the same URL prefix for multiple iOS apps/targets contained in the same Firebase project. 

### Solution: Using multiple (sub)domains

It works, if each iOS app uses its own (sub)domain for dynamic links. For instance, instead of using only pets.page.link for all targets, use cats.page.link for your first app target and dogs.page.link for your second app target. The crucial requirement for this is that each of your target's Associated Domains Entitlement contains only the (sub)domain(s) it should listen to.

### Custom domain

Additionally we're moving to custom sub-domains based on `joinself.com` to manage all dynamic links.

This will require changes both on `ios` and `android`

[Reference](https://stackoverflow.com/questions/41582867/firebase-dynamic-links-is-not-working-for-different-target-in-same-project-in-io/61208739#61208739)
