### PR TITLE
Support redirections

### DIFF
--- a/_examples/authentication_dl/authentication.go
+++ b/_examples/authentication_dl/authentication.go
@@ -35,9 +35,13 @@ func main() {
 	authService := client.AuthenticationService()
 	cid := uuid.New().String()
 
+	// You can manage your redirection codes on your app management on the
+	// developer portal
+	redirectionCode := "90d017d1"
+
 	req := authentication.DeepLinkAuthenticationRequest{
 		ConversationID: cid,
-		Callback:       "https://www.joinself.com",
+		Callback:       redirectionCode,
 		Expiry:         time.Minute * 5,
 	}
 

--- a/_examples/fact_request_dl/fact.go
+++ b/_examples/fact_request_dl/fact.go
@@ -39,10 +39,14 @@ func main() {
 
 	log.Println("requesting user information")
 
+	// You can manage your redirection codes on your app management on the
+	// developer portal
+	redirectionCode := "90d017d1"
+
 	req := fact.DeepLinkFactRequest{
 		ConversationID: cid,
 		Description:    "info",
-		Callback:       "https://www.joinself.com",
+		Callback:       redirectionCode,
 		Facts: []fact.Fact{
 			{
 				Fact:    fact.FactPhoneNumber,

--- a/chat/actions.go
+++ b/chat/actions.go
@@ -4,6 +4,7 @@ package chat
 
 import (
 	"encoding/base64"
+	"fmt"
 	"strings"
 	"time"
 
@@ -214,14 +215,21 @@ func (s *Service) GenerateConnectionDeepLink(config ConnectionConfig) (string, e
 		return "", err
 	}
 
-	url := "https://links.joinself.com/?link=" + callback + "%3Fqr=" + base64.RawStdEncoding.EncodeToString(payload)
-	if s.environment == "" {
-		return url + "&apn=com.joinself.app", nil
-	} else if s.environment == "development" {
-		return url + "&apn=com.joinself.app.dev", nil
+	body := base64.RawStdEncoding.EncodeToString(payload)
+	baseURL := fmt.Sprintf("https://%s.links.joinself.com", s.environment)
+	portalURL := fmt.Sprintf("https://developer.%s.joinself.com", s.environment)
+	apn := fmt.Sprintf("com.joinself.app.%s", s.environment)
+
+	if s.environment == "" || s.environment == "development" {
+		baseURL = "https://links.joinself.com"
+		portalURL = "https://developer.joinself.com"
+		apn = "com.joinself.app"
+		if s.environment == "development" {
+			apn = "com.joinself.com.dev"
+		}
 	}
 
-	return "https://" + s.environment + ".links.joinself.com/?link=" + callback + "%3Fqr=" + base64.RawStdEncoding.EncodeToString(payload) + "&apn=com.joinself.app." + s.environment, nil
+	return fmt.Sprintf("%s?link=%s/callback/%s%%3Fqr=%s&apn=%s", baseURL, portalURL, callback, body, apn), nil
 }
 
 func (s *Service) buildConnectionRequest(exp time.Duration) ([]byte, error) {

--- a/fact/request.go
+++ b/fact/request.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -345,13 +346,20 @@ func (s Service) GenerateDeepLink(req *DeepLinkFactRequest) (string, error) {
 		return "", err
 	}
 
-	url := "https://links.joinself.com/?link=" + req.Callback + "%3Fqr=" + base64.RawStdEncoding.EncodeToString(payload)
-	if s.environment == "" {
-		return url + "&apn=com.joinself.app", nil
-	} else if s.environment == "development" {
-		return url + "&apn=com.joinself.app.dev", nil
+	body := base64.RawStdEncoding.EncodeToString(payload)
+	baseURL := fmt.Sprintf("https://%s.links.joinself.com", s.environment)
+	portalURL := fmt.Sprintf("https://developer.%s.joinself.com", s.environment)
+	apn := fmt.Sprintf("com.joinself.app.%s", s.environment)
+
+	if s.environment == "" || s.environment == "development" {
+		baseURL = "https://links.joinself.com"
+		portalURL = "https://developer.joinself.com"
+		apn = "com.joinself.app"
+		if s.environment == "development" {
+			apn = "com.joinself.com.dev"
+		}
 	}
-	return "https://" + s.environment + ".links.joinself.com/?link=" + req.Callback + "%3Fqr=" + base64.RawStdEncoding.EncodeToString(payload) + "&apn=com.joinself.app." + s.environment, nil
+	return fmt.Sprintf("%s?link=%s/callback/%s%%3Fqr=%s&apn=%s", baseURL, portalURL, req.Callback, body, apn), nil
 }
 
 // WaitForResponse waits for completion of a fact request that was initiated by qr code


### PR DESCRIPTION
Dynamic link redirections will be managed through the developer portal from now on

This means from now on, a developer must create a redirection for an app, and use the generated unique identifier with the helpers generating dynamic links on the sdks.