### PR TITLE
Explicitly start self client

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ func main() {
     }
 
     client, err := selfsdk.New(cfg)
+    client.Start()
 }
 ```
 
@@ -126,6 +127,7 @@ import (
 
 func main() {
     client, err := selfsdk.New(cfg)
+    client.Start()
     ...
 
     svc := client.Facts()
@@ -156,6 +158,7 @@ import (
 
 func main() {
     client, err := selfsdk.New("appID", "privateKey")
+    client.Start()
     ...
 
     svc := client.Authentication()

--- a/_examples/authentication/authentication.go
+++ b/_examples/authentication/authentication.go
@@ -27,6 +27,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	client.Start()
 
 	if len(os.Args) < 2 {
 		panic("you must specify a self id as an argument")

--- a/_examples/authentication_dl/authentication.go
+++ b/_examples/authentication_dl/authentication.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	client.Start()
 
 	log.Println("authenticating user")
 

--- a/_examples/authentication_qr/authentication.go
+++ b/_examples/authentication_qr/authentication.go
@@ -33,6 +33,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	client.Start()
 
 	s := server{
 		cid:  uuid.New().String(),

--- a/_examples/chat/chat.go
+++ b/_examples/chat/chat.go
@@ -90,6 +90,9 @@ func main() {
 		delete(groups, gid)
 	})
 
+	// Start the client
+	client.Start()
+
 	// Public object
 	obj := chat.MessageObject{
 		Name: "Hello",

--- a/_examples/connection/app.go
+++ b/_examples/connection/app.go
@@ -33,6 +33,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	client.Start()
 
 	s := server{
 		cid:  uuid.New().String(),

--- a/_examples/connections/connections.go
+++ b/_examples/connections/connections.go
@@ -28,6 +28,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	client.Start()
 
 	if len(os.Args) < 2 {
 		panic("you must specify a self id as an argument")

--- a/_examples/documents/sign.go
+++ b/_examples/documents/sign.go
@@ -30,6 +30,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	client.Start()
 
 	if len(os.Args) < 2 {
 		panic("you must specify a self id as an argument")

--- a/_examples/fact_request/custom.go
+++ b/_examples/fact_request/custom.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	client.Start()
 
 	err = client.MessagingService().PermitConnection("*")
 	if err != nil {

--- a/_examples/fact_request/delegation.go
+++ b/_examples/fact_request/delegation.go
@@ -30,6 +30,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	client.Start()
 
 	err = client.MessagingService().PermitConnection("*")
 	if err != nil {

--- a/_examples/fact_request/fact.go
+++ b/_examples/fact_request/fact.go
@@ -28,6 +28,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	client.Start()
 
 	err = client.MessagingService().PermitConnection("*")
 	if err != nil {

--- a/_examples/fact_request_dl/fact.go
+++ b/_examples/fact_request_dl/fact.go
@@ -31,6 +31,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	client.Start()
 
 	err = client.MessagingService().PermitConnection("*")
 	if err != nil {

--- a/_examples/fact_request_intermediary/fact.go
+++ b/_examples/fact_request_intermediary/fact.go
@@ -28,6 +28,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	client.Start()
 
 	if len(os.Args) < 2 {
 		panic("you must specify a self id as an argument")

--- a/_examples/fact_request_qr/fact.go
+++ b/_examples/fact_request_qr/fact.go
@@ -32,6 +32,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	client.Start()
 
 	s := server{
 		cid:  uuid.New().String(),

--- a/client.go
+++ b/client.go
@@ -38,6 +38,7 @@ type WebsocketTransport interface {
 // MessagingClient defines the interface required for the sdk to perform
 // operations against self's messaging service
 type MessagingClient interface {
+	Start()
 	Send(recipients []string, mtype string, plaintext []byte) error
 	Request(recipients []string, cid string, mtype string, data []byte, timeout time.Duration) (string, []byte, error)
 	Register(cid string)
@@ -105,6 +106,10 @@ func New(cfg Config) (*Client, error) {
 	time.Local = utcZone
 
 	return client, nil
+}
+
+func (c *Client) Start() {
+	c.MessagingService().Start()
 }
 
 // FactService returns a client for working with facts

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,6 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	golang.org/x/net v0.0.0-20200222125558-5a598a2470a0 // indirect
-	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
+	golang.org/x/sys v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/messaging/client.go
+++ b/messaging/client.go
@@ -16,6 +16,7 @@ type restTransport interface {
 
 // messagingClient handles all interactions with self messaging and its users
 type messagingClient interface {
+	Start()
 	Send(recipients []string, mtype string, data []byte) error
 	Request(recipients []string, cid string, mtype string, data []byte, timeout time.Duration) (string, []byte, error)
 	Subscribe(msgType string, sub func(sender string, payload []byte))

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -48,6 +48,10 @@ type infoNotification struct {
 	Description  string    `json:"description"`
 }
 
+func (s *Service) Start() {
+	s.messaging.Start()
+}
+
 // Subscribe subscribe to messages of a given type
 func (s *Service) Subscribe(messageType string, h func(m *Message)) {
 	s.messaging.Subscribe(messageType, func(sender string, payload []byte) {

--- a/messaging/support_test.go
+++ b/messaging/support_test.go
@@ -27,6 +27,11 @@ type testMessaging struct {
 	out       map[string][]byte
 	responder func(r map[string]string) (string, []byte, error)
 	sendError error
+	started   bool
+}
+
+func (c *testMessaging) Start() {
+	c.started = true
 }
 
 func (c *testMessaging) Send(recipients []string, mtype string, data []byte) error {

--- a/pkg/messaging/messaging.go
+++ b/pkg/messaging/messaging.go
@@ -89,6 +89,7 @@ type Client struct {
 	acl           *unsafe.Pointer
 	closing       chan struct{}
 	closed        chan struct{}
+	started       bool
 }
 
 // New create a new messaging client
@@ -131,9 +132,8 @@ func New(config Config) (*Client, error) {
 		acl:       &emptyACL,
 		closing:   make(chan struct{}, 1),
 		closed:    make(chan struct{}, 1),
+		started:   false,
 	}
-
-	go c.reader()
 
 	conns, err := c.ListConnections()
 	if err != nil {
@@ -143,6 +143,16 @@ func New(config Config) (*Client, error) {
 	atomic.StorePointer(c.acl, unsafe.Pointer(&conns))
 
 	return &c, nil
+}
+
+// Start starts the connection with self network.
+func (c *Client) Start() {
+	if c.started {
+		return
+	}
+
+	go c.reader()
+	c.started = true
 }
 
 // Send sends an encypted message to recipients

--- a/pkg/messaging/messaging_test.go
+++ b/pkg/messaging/messaging_test.go
@@ -23,6 +23,7 @@ func TestMessagingSend(t *testing.T) {
 
 	c, err := New(cfg)
 	require.Nil(t, err)
+	c.Start()
 
 	err = c.Send([]string{"alice:1"}, "test.message", []byte("test"))
 	require.Nil(t, err)
@@ -56,6 +57,7 @@ func TestMessagingRequest(t *testing.T) {
 
 	c, err := New(cfg)
 	require.Nil(t, err)
+	c.Start()
 
 	go func() {
 		<-ws.out
@@ -81,6 +83,7 @@ func TestMessagingRegisterWait(t *testing.T) {
 
 	c, err := New(cfg)
 	require.Nil(t, err)
+	c.Start()
 
 	_, _, err = c.Wait("1", time.Millisecond)
 	require.NotNil(t, err)
@@ -122,6 +125,7 @@ func TestMessagingSubscribe(t *testing.T) {
 
 	c, err := New(cfg)
 	require.Nil(t, err)
+	c.Start()
 
 	resp := make(chan *testEvent, 1)
 
@@ -152,6 +156,7 @@ func TestMessagingClose(t *testing.T) {
 
 	c, err := New(cfg)
 	require.Nil(t, err)
+	c.Start()
 
 	time.Sleep(time.Millisecond * 100)
 


### PR DESCRIPTION
On some situations a client can receive queued messages before a subscription has been setup. 

This happens because the websocket connection starts before the subscription is registered. An example:
```go
	client, err := selfsdk.New(cfg)
	if err != nil {
		panic(err)
	}

	client.ChatService().OnMessage(func(cm *chat.Message) {
              //....
        }
```

A proposal to amend this is to split sdk initialization on a 2 step process, first initialize the client, and second start it. With this approach you'll be able to setup message subscriptions before the client starts receiving any messages.
```go
	client, err := selfsdk.New(cfg)
	if err != nil {
		panic(err)
	}

	client.ChatService().OnMessage(func(cm *chat.Message) {
              //....
        }

        client.Start()
```
