### PR TITLE
Expose build request

### DIFF
--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -196,6 +196,50 @@ func (s *Service) Send(recipients []string, conversationID string, body []byte) 
 	return s.messaging.Send(recipients, gjson.GetBytes(body, "typ").String(), []byte(plaintext))
 }
 
+// BuildRequest creates a request payload with the given payload, and returns
+// the payload as a byte array. It generates a new request ID, JWT ID, and
+// timestamps for the request. If the payload does not contain a "typ" key, it
+// returns an empty byte array and an error. If the payload contains a "sub"
+// key but not an "aud" key, it sets the "aud" key to the value of "sub". It
+// then calls the PrepareJWS function to prepare a JWS token with the request
+// payload, and returns the JWS token as a byte array.
+//
+// Parameters:
+//   - payload: A map of string keys to interface{} values representing the
+//     payload of the request.
+//
+// Returns:
+//   - []byte: A byte array representing the prepared JWS token.
+//   - error: An error that is non-nil if the payload does not contain a "typ"
+//     key.
+func (s *Service) BuildRequest(payload map[string]interface{}) ([]byte, error) {
+	req := map[string]interface{}{
+		"cid":       uuid.New().String(),
+		"jti":       uuid.New().String(),
+		"iss":       s.selfID,
+		"iat":       ntp.TimeFunc().Format(time.RFC3339),
+		"exp":       ntp.TimeFunc().Add(time.Minute * 15).Format(time.RFC3339),
+		"device_id": s.deviceID,
+	}
+
+	for key, value := range payload {
+		req[key] = value
+	}
+
+	if _, ok := req["typ"]; !ok {
+		return []byte{}, errors.New("missing typ")
+	}
+
+	if _, ok := req["sub"]; ok {
+		if _, ok := req["aud"]; !ok {
+			req["aud"] = req["sub"]
+		}
+	}
+
+	body, err := helpers.PrepareJWS(req, s.keyID, s.sk)
+	return body, err
+}
+
 // Notify sends a notification to a given self ID
 func (s *Service) Notify(selfID, content string) error {
 	cid := uuid.New().String()

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -832,3 +832,48 @@ func TestMessagingRespond(t *testing.T) {
 	assert.Equal(t, "sender", r["iss"])
 	assert.Equal(t, "test", r["aud"])
 }
+
+func TestMessagingBuildRequest(t *testing.T) {
+	apk, ask, err := ed25519.GenerateKey(rand.Reader)
+	require.Nil(t, err)
+
+	m, p := setup(t)
+
+	cfg := Config{
+		SelfID:     "test",
+		PrivateKey: ask,
+		PKI:        p,
+		Messaging:  m,
+	}
+
+	payload := map[string]interface{}{
+		"typ": "test",
+		"jti": "12345",
+		"iss": "sender",
+		"aud": "test",
+		"sub": "sender",
+		"cid": "conversation",
+		"exp": time.Now().Add(time.Minute).Format(time.RFC3339),
+		"iat": time.Now().Format(time.RFC3339),
+	}
+
+	s := NewService(cfg)
+
+	res, err := s.BuildRequest(payload)
+	require.Nil(t, err)
+
+	jws, err := jose.ParseSigned(string(res))
+	require.Nil(t, err)
+
+	rp, err := jws.Verify(apk)
+	require.Nil(t, err)
+
+	var r map[string]string
+
+	err = json.Unmarshal(rp, &r)
+	require.Nil(t, err)
+
+	assert.Equal(t, "conversation", r["cid"])
+	assert.Equal(t, "sender", r["iss"])
+	assert.Equal(t, "test", r["aud"])
+}


### PR DESCRIPTION
In order to generate custom request payloads (to build QR codes) we need to expose a method on the messaging client.