### PR TITLE
Fix "undefined authentication.QRConfig" error.

### DIFF
--- a/_examples/authentication_qr/service/authentication_service.go
+++ b/_examples/authentication_qr/service/authentication_service.go
@@ -34,6 +34,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer func() {
+		err = client.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+	err = client.MessagingService().PermitConnection("*")
+	if err != nil {
+		log.Fatal("permitting connection returned with: ", err)
+	}
 
 	s := server{
 		cid:  uuid.New().String(),
@@ -60,7 +70,6 @@ func main() {
 	openbrowser("http://localhost:9999/qr.png")
 
 	log.Println("waiting for response")
-
 	client.AuthenticationService().Subscribe(func(sender, cid string, authenticated bool) {
 		log.Println("cid: " + cid)
 		if authenticated {
@@ -69,12 +78,9 @@ func main() {
 			log.Println("authentication rejected by " + sender)
 		}
 	})
+	println("Hit control+C to exit")
 	WaitForCtrlC()
-
-	err = client.Close()
-	if err != nil {
-		log.Fatal(err)
-	}
+	os.Exit(0)
 }
 
 type server struct {

--- a/authentication/client.go
+++ b/authentication/client.go
@@ -28,6 +28,8 @@ type Config struct {
 	Requester *fact.Service
 }
 
+type QRConfig = fact.QRConfig
+
 // NewService creates a new client for interacting with facts
 func NewService(cfg Config) *Service {
 	return &Service{


### PR DESCRIPTION
After the refactor to use fact requests exclusively, all QR authentication requests now require a `fact.QRConfig` object to be set up. This adds an extra dependency for developers using this functionality.

This pull request creates an alias of `fact.QRConfig` within the authentication package, making it easier to use for developers and resolving the "undefined authentication.QRConfig" error.

Fixes #147 