### PR TITLE
load correct sessions by sender when encrypting

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -312,13 +312,13 @@ func (s *Storage) Encrypt(from string, to []string, plaintext []byte) ([]byte, e
 		var with string
 		var sessionPickle string
 
-		log.Printf("loaded session pickle (encrypt): %s", sessionPickle)
-
 		err := rows.Scan(&with, &sessionPickle)
 		if err != nil {
 			txn.Rollback()
 			return nil, err
 		}
+
+		log.Printf("loaded session pickle (encrypt): %s", sessionPickle)
 
 		session, err := selfcrypto.SessionFromPickle(with, s.ec, sessionPickle)
 		if err != nil {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -291,17 +291,18 @@ func (s *Storage) Encrypt(from string, to []string, plaintext []byte) ([]byte, e
 	}
 
 	statement := fmt.Sprintf(
-		"SELECT with_identifier, olm_session FROM sessions WHERE as_identifier = %s with_identifier IN(?%s)",
-		from,
+		"SELECT with_identifier, olm_session FROM sessions WHERE as_identifier = ? AND with_identifier IN(?%s)",
 		strings.Repeat(",?", len(to)-1),
 	)
 
-	recipients := make([]any, len(to))
+	args := make([]any, len(to)+1)
+	args[0] = from
+
 	for i := range to {
-		recipients[i] = to[i]
+		args[i+1] = to[i]
 	}
 
-	rows, err := txn.Query(statement, recipients...)
+	rows, err := txn.Query(statement, args...)
 	if err != nil {
 		txn.Rollback()
 		return nil, err

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -417,6 +418,7 @@ func (s *Storage) Decrypt(from, to string, offset int64, ciphertext []byte) ([]b
 			return nil, err
 		}
 
+		log.Printf("creating new inbound session from: %s to: %s", from, to)
 		session, otks, err = s.createInboundSession(txn, from, to, otkm)
 		if err != nil {
 			txn.Rollback()
@@ -424,6 +426,8 @@ func (s *Storage) Decrypt(from, to string, offset int64, ciphertext []byte) ([]b
 		}
 	} else {
 		sessionExisting = true
+
+		log.Printf("loaded existing inbound session from: %s to: %s", from, to)
 
 		session, err = selfcrypto.SessionFromPickle(from, s.ec, sessionPickle)
 		if err != nil {
@@ -441,6 +445,8 @@ func (s *Storage) Decrypt(from, to string, offset int64, ciphertext []byte) ([]b
 		// so create a new inbound session as this is a
 		// one time key message
 		if otkm.Type == 0 && !matches {
+			log.Printf("existing inbound session does not match, creating new one from: %s to: %s", from, to)
+
 			session, otks, err = s.createInboundSession(txn, from, to, otkm)
 			if err != nil {
 				txn.Rollback()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ed25519"
 	"database/sql"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -311,6 +312,8 @@ func (s *Storage) Encrypt(from string, to []string, plaintext []byte) ([]byte, e
 		var with string
 		var sessionPickle string
 
+		log.Printf("loaded session pickle (encrypt): %s", sessionPickle)
+
 		err := rows.Scan(&with, &sessionPickle)
 		if err != nil {
 			txn.Rollback()
@@ -363,6 +366,8 @@ func (s *Storage) Encrypt(from string, to []string, plaintext []byte) ([]byte, e
 			return nil, err
 		}
 
+		log.Printf("storing session pickle (encrypt): %s", sessionPickle)
+
 		_, ok := foundSessions[to[i]]
 		if ok {
 			_, err = txn.Exec("UPDATE sessions SET olm_session = ? WHERE as_identifier = ? AND with_identifier = ?;", sessionPickle, from, to[i])
@@ -375,6 +380,8 @@ func (s *Storage) Encrypt(from string, to []string, plaintext []byte) ([]byte, e
 			return nil, err
 		}
 	}
+
+	log.Printf("ciphertext: %s", hex.EncodeToString(ciphertext))
 
 	return ciphertext, txn.Commit()
 }
@@ -428,6 +435,7 @@ func (s *Storage) Decrypt(from, to string, offset int64, ciphertext []byte) ([]b
 		sessionExisting = true
 
 		log.Printf("loaded existing inbound session from: %s to: %s", from, to)
+		log.Printf("loaded session pickle (decrypt): %s", sessionPickle)
 
 		session, err = selfcrypto.SessionFromPickle(from, s.ec, sessionPickle)
 		if err != nil {
@@ -472,6 +480,8 @@ func (s *Storage) Decrypt(from, to string, offset int64, ciphertext []byte) ([]b
 		txn.Rollback()
 		return nil, err
 	}
+
+	log.Printf("storing session pickle (decrypt): %s", sessionPickle)
 
 	if sessionExisting {
 		_, err = txn.Exec("UPDATE sessions SET olm_session = ? WHERE as_identifier = ? AND with_identifier = ?;", sessionPickle, to, from)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -318,7 +318,7 @@ func (s *Storage) Encrypt(from string, to []string, plaintext []byte) ([]byte, e
 			return nil, err
 		}
 
-		log.Printf("loaded session pickle (encrypt): %s", sessionPickle)
+		log.Printf("loaded session pickle (encrypt): %s with: %s", sessionPickle, with)
 
 		session, err := selfcrypto.SessionFromPickle(with, s.ec, sessionPickle)
 		if err != nil {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -291,7 +291,8 @@ func (s *Storage) Encrypt(from string, to []string, plaintext []byte) ([]byte, e
 	}
 
 	statement := fmt.Sprintf(
-		"SELECT with_identifier, olm_session FROM sessions WHERE with_identifier IN(?%s)",
+		"SELECT with_identifier, olm_session FROM sessions WHERE as_identifier = %s with_identifier IN(?%s)",
+		from,
 		strings.Repeat(",?", len(to)-1),
 	)
 


### PR DESCRIPTION
- [x] fix issue where multiple sessions were being incorrectly loaded for a given recipient when multiple existed under different `as_identifier` records.