### PR TITLE
Default message "exp" expiration date

### DIFF
--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -89,7 +89,11 @@ func (s *Service) Subscribe(messageType string, h func(m *Message)) {
 			return
 		}
 
-		if ntp.TimeFunc().After(mp.ExpiresAt) {
+		expiresAt := mp.ExpiresAt
+		if mp.ExpiresAt.IsZero() {
+			expiresAt = mp.IssuedAt.Add(24 * time.Hour)
+		}
+		if ntp.TimeFunc().After(expiresAt) {
 			log.Println("messaging:", ErrMessageExpired.Error())
 			return
 		}


### PR DESCRIPTION
Add a default expiration time for all incoming messages not specifying the exp to 1 day in case it’s not provided. 

Expiration date will infered from the `iat` field which is always provided.