### PR TITLE
Update Local Development Environment Configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -105,11 +105,19 @@ func (c *Config) load() error {
 
 	if c.Environment != "" {
 		if c.APIURL == "" {
-			c.APIURL = "https://api." + c.Environment + ".joinself.com"
+			if c.Environment == "development" {
+				c.APIURL = "http://localhost:8080"
+			} else {
+				c.APIURL = "https://api." + c.Environment + ".joinself.com"
+			}
 		}
 
 		if c.MessagingURL == "" {
-			c.MessagingURL = "wss://messaging." + c.Environment + ".joinself.com/v2/messaging"
+			if c.Environment == "development" {
+				c.MessagingURL = "ws://localhost:8086/v2/messaging"
+			} else {
+				c.MessagingURL = "wss://messaging." + c.Environment + ".joinself.com/v2/messaging"
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request introduces an update to the `config.go` file to simplify the setup process for local development environments.

#### Changes
- The API URL and Messaging URL default values are now automatically set to point to localhost endpoints when the `Environment` is set to `development`.
- For environments other than `development`, the URLs default to the relative environment endpoints.

This change makes it easier for developers to build and test features locally, as they no longer need to manually set local endpoints in the configuration.

#### Testing
Ensure that when the `Environment` is set to `development`, the API URL and Messaging URL are correctly pointing to `http://localhost:8080` and `ws://localhost:8086/v2/messaging` respectively. For any other environment setting, URLs should point to the appropriate `joinself.com` subdomains with the correct protocol (`https` and `wss`).
