### PR TITLE
Issue objects as custom facts

### DIFF
--- a/_examples/fact_request/custom_objects.go
+++ b/_examples/fact_request/custom_objects.go
@@ -1,0 +1,115 @@
+// Copyright 2020 Self Group Ltd. All Rights Reserved.
+
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	selfsdk "github.com/joinself/self-go-sdk"
+	"github.com/joinself/self-go-sdk/fact"
+)
+
+// expects 1 argument - the Self ID you want to authenticate
+func main() {
+	appID := os.Getenv("SELF_APP_ID")
+	cfg := selfsdk.Config{
+		SelfAppID:           appID,
+		SelfAppDeviceSecret: os.Getenv("SELF_APP_DEVICE_SECRET"),
+		StorageKey:          "my-secret-crypto-storage-key",
+		StorageDir:          "../.storage/",
+	}
+
+	if os.Getenv("SELF_ENV") != "" {
+		cfg.Environment = os.Getenv("SELF_ENV")
+	}
+
+	client, err := selfsdk.New(cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		err = client.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	err = client.Start()
+	if err != nil {
+		panic(err)
+	}
+
+	if len(os.Args) < 2 {
+		panic("you must specify a self id as an argument")
+	}
+
+	log.Println("issuing custom facts with objects attached")
+	selfid := os.Args[1]
+	source := "Custom Objects"
+	content, err := ioutil.ReadFile("./my_image.png")
+	if err != nil {
+		log.Fatal(err)
+	}
+	obj, err := client.NewObject(content, "test", "image/png")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	f := []fact.FactToIssue{
+		fact.FactToIssue{
+			Key:    "my-image",
+			Value:  obj.Digest,
+			Source: source,
+			Object: obj,
+		},
+	}
+
+	client.FactService().Issue(selfid, f, []string{})
+	time.Sleep(5 * time.Second)
+
+	log.Println("requesting custom facts with objects")
+	req := fact.FactRequest{
+		SelfID:      selfid,
+		Description: "This is a sample of issuing custom objects",
+		Facts: []fact.Fact{
+			{
+				Fact:    f[0].Key,
+				Sources: []string{source},
+				Issuers: []string{appID},
+			},
+		},
+		Expiry: time.Minute * 5,
+	}
+
+	factService := client.FactService()
+
+	resp, err := factService.Request(&req)
+	if err != nil {
+		log.Fatal("fact request returned with: ", err)
+	}
+
+	digests := []string{}
+	for _, f := range resp.Facts {
+		log.Println(f.Fact, ":", f.AttestedValues())
+		digests = append(digests, f.AttestedValues()...)
+	}
+
+	for _, d := range digests {
+		if _, ok := resp.Objects[d]; ok {
+			ct, err := resp.Objects[d].GetContent()
+			if err != nil {
+				log.Fatal(err)
+			}
+			err = ioutil.WriteFile("/tmp/output-go.jpg", ct, 0644)
+			if err != nil {
+				log.Fatal(err)
+			}
+			println("file stored on /tmp/output-go.jpg")
+		}
+	}
+
+}

--- a/client.go
+++ b/client.go
@@ -200,6 +200,13 @@ func (c *Client) VoiceService() *voice.Service {
 	return voice.NewService(cfg)
 }
 
+// NewObject creates a new object from the provided data.
+func (c *Client) NewObject(data []byte, name, mime string) (*object.Object, error) {
+	o := object.New(c.connectors.FileInteractor)
+	err := o.BuildFromData(data, name, mime)
+	return o, err
+}
+
 // Rest provides access to the rest client to interact used by the sdk.
 func (c *Client) Rest() RestTransport {
 	return c.config.Connectors.Rest

--- a/fact/issue.go
+++ b/fact/issue.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/joinself/self-go-sdk/pkg/helpers"
 	"github.com/joinself/self-go-sdk/pkg/ntp"
+	"github.com/joinself/self-go-sdk/pkg/object"
 	"gopkg.in/square/go-jose.v2"
 )
 
@@ -26,6 +27,7 @@ type FactToIssue struct {
 	Group      *FactGroup     `json:"group,omitempty"`
 	Type       string         `json:"type,omitempty"`
 	ExpTimeout *time.Duration `json:"-"`
+	Object     *object.Object `json:"-"`
 }
 
 func (f *FactToIssue) validate() error {
@@ -132,6 +134,14 @@ func (s *Service) sendIssuedFacts(selfID string, facts []FactToIssue, viewers []
 		attestations[i] = json.RawMessage(attestation.FullSerialize())
 	}
 
+	objects := make([]map[string]interface{}, 0)
+	for _, f := range facts {
+		if f.Object != nil {
+			objects = append(objects, f.Object.ToPayload())
+		}
+
+	}
+
 	req := map[string]interface{}{
 		"typ":          "identities.facts.issue",
 		"iss":          s.selfID,
@@ -143,6 +153,7 @@ func (s *Service) sendIssuedFacts(selfID string, facts []FactToIssue, viewers []
 		"jti":          uuid.New().String(),
 		"status":       "verified",
 		"attestations": attestations,
+		"objects":      objects,
 		"viewers":      viewers,
 	}
 

--- a/fact/request.go
+++ b/fact/request.go
@@ -211,7 +211,11 @@ func (s Service) Request(req *FactRequest) (*FactResponse, error) {
 		fo := object.New(s.fileInteractor)
 		o["name"] = o["id"]
 		if err := fo.BuildFromObject(o); err == nil {
-			objects[o["image_hash"].(string)] = fo
+			if _, ok := o["image_hash"]; ok {
+				objects[o["image_hash"].(string)] = fo
+			} else if _, ok := o["object_hash"]; ok {
+				objects[o["object_hash"].(string)] = fo
+			}
 		}
 	}
 

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -3,6 +3,9 @@
 package object
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
 	"log"
 	"strconv"
 )
@@ -22,6 +25,8 @@ type Object struct {
 	Key        string
 	Nonce      string
 	Ciphertext string
+	Content    []byte
+	Digest     string
 }
 
 // New creates an object.
@@ -46,6 +51,8 @@ func (o *Object) BuildFromData(data []byte, name, mime string) error {
 	o.Key = obj.Key
 	o.Mime = mime
 	o.Expires = obj.Expires
+	o.Content = data
+	o.Digest = o.calculateDigest(data)
 
 	return nil
 }
@@ -57,6 +64,11 @@ func (o *Object) BuildFromObject(obj map[string]interface{}) error {
 	if _, ok := obj["key"]; ok {
 		o.Key = obj["key"].(string)
 		o.Mime = obj["mime"].(string)
+		if val, ok := obj["object_hash"]; ok {
+			o.Digest = val.(string)
+		} else if val, ok := obj["image_hash"]; ok {
+			o.Digest = val.(string)
+		}
 		if exp, exists := obj["expires"]; exists {
 			switch v := exp.(type) {
 			case string:
@@ -75,12 +87,13 @@ func (o *Object) BuildFromObject(obj map[string]interface{}) error {
 // ToPayload translates the current object to payload.
 func (o *Object) ToPayload() map[string]interface{} {
 	return map[string]interface{}{
-		"name":    o.Name,
-		"link":    o.Link,
-		"key":     o.Key,
-		"mime":    o.Mime,
-		"expires": strconv.FormatInt(o.Expires, 10),
-		"public":  false,
+		"name":        o.Name,
+		"link":        o.Link,
+		"key":         o.Key,
+		"mime":        o.Mime,
+		"expires":     strconv.FormatInt(o.Expires, 10),
+		"public":      false,
+		"object_hash": o.Digest,
 	}
 }
 
@@ -92,6 +105,14 @@ func (o *Object) GetContent() ([]byte, error) {
 		println(err.Error())
 		return []byte(""), err
 	}
+	if o.calculateDigest(content) != o.Digest {
+		return content, errors.New("object digest and content digest do not match")
+	}
 
 	return content, nil
+}
+
+func (o *Object) calculateDigest(ct []byte) string {
+	h := sha256.Sum256(ct)
+	return base64.RawURLEncoding.EncodeToString(h[:])
 }


### PR DESCRIPTION
This pull request extends the fact issuing and retrieving capabilities of this SDK to allow the developer issue signed objects (images, pdfs...) and retrieve them.

Processing incoming objects has been improved by checking the signed object hash, signed using the SHA256 algorithm.

You can find an example of how to use this new features at examples/fact_request/custom_objects.rb

